### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,8 +92,8 @@
     "@storybook/components": "^6.3.6",
     "@storybook/core-events": "^6.3.6",
     "@storybook/theming": "^6.3.6",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0" || ^18.0.0,
+    "react-dom": "^16.8.0 || ^17.0.0" || ^18.0.0
   },
   "peerDependenciesMeta": {
     "react": {


### PR DESCRIPTION
From what I can see the addon runs without issue in React 18 projects. Bumping peer dependency to include React 18 so it doesn't need to be force installed.